### PR TITLE
Filter on HTTP method

### DIFF
--- a/mediator/tenants/migrations/0002_upstream_http_methods.py
+++ b/mediator/tenants/migrations/0002_upstream_http_methods.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+import tenants.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tenants', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='upstream',
+            name='http_methods',
+            field=models.CharField(
+                default='',
+                max_length=200,
+                validators=[tenants.models.validate_http_methods]
+            ),
+        ),
+    ]

--- a/mediator/tenants/models.py
+++ b/mediator/tenants/models.py
@@ -1,7 +1,27 @@
 from cryptography.fernet import Fernet
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
+from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+def validate_http_methods(value: str):
+    """
+    Validates that ``value`` is a space-separated list of HTTP methods,
+    or an empty string to denote all methods.
+    """
+    if value == '':
+        return
+    valid = {'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS',
+             'TRACE', 'PATCH'}
+    values = set(value.upper().split())
+    if invalid := values - valid:
+        if len(invalid) == 1:
+            message = _('%(invalid)s is not a valid HTTP method')
+        else:
+            message = _('%(invalid)s are not valid HTTP methods')
+        raise ValidationError(message, params={'invalid': ','.join(invalid)})
 
 
 class Tenant(models.Model):
@@ -19,6 +39,9 @@ class Upstream(models.Model):
     tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
     short_name = models.SlugField(max_length=200, db_index=True)
     base_url = models.URLField()
+    # A space-separated list of HTTP methods or an empty string to denote all
+    http_methods = models.CharField(max_length=200, default='',
+                                    validators=[validate_http_methods])
     verify_cert = models.BooleanField(default=True)
     username = models.CharField(max_length=200)
     # NOTE: If settings.SECRET_KEY is changed, passwords cannot be decrypted
@@ -26,6 +49,10 @@ class Upstream(models.Model):
 
     def __str__(self):
         return str(self.short_name)
+
+    def save(self, *args, **kwargs):
+        self.http_methods = self.http_methods.upper()
+        super().save(*args, **kwargs)
 
     @property
     def password(self):

--- a/mediator/tenants/tests/test_models.py
+++ b/mediator/tenants/tests/test_models.py
@@ -1,0 +1,38 @@
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
+
+from tenants.models import validate_http_methods
+
+
+class TestValidateHTTPMethods(SimpleTestCase):
+
+    def test_empty_value(self):
+        validate_http_methods('')
+
+    def test_valid_value(self):
+        validate_http_methods('POST')
+
+    def test_lower_value(self):
+        validate_http_methods('get')
+
+    def test_valid_values(self):
+        validate_http_methods('GET POST PUT')
+
+    def test_lower_values(self):
+        validate_http_methods('options patch')
+
+    def test_invalid_value(self):
+        with self.assertRaises(ValidationError):
+            validate_http_methods('OPTION')
+
+    def test_invalid_values(self):
+        with self.assertRaises(ValidationError):
+            validate_http_methods('CREATE UPDATE')
+
+    def test_comma_separator(self):
+        with self.assertRaises(ValidationError):
+            validate_http_methods('GET,POST')
+
+    def test_comma_space_separator(self):
+        with self.assertRaises(ValidationError):
+            validate_http_methods('GET, POST')

--- a/mediator/tenants/views.py
+++ b/mediator/tenants/views.py
@@ -45,7 +45,7 @@ def forward_request_upstream(request, upstream, path):
     headers = get_http_headers(request.META)
     request_ts = datetime.utcnow()
     response = requests.request(
-        request.method.lower(),
+        request.method,
         url,
         params=QueryDict(query_string),
         data=data,
@@ -97,7 +97,9 @@ def get_http_headers(request_meta):
     {'Accept-Language': 'xh'}
 
     """
-    headers = {k[5:].replace('_', '-').title(): v for k, v in request_meta.items() if k.startswith('HTTP_')}
+    headers = {k[5:].replace('_', '-').title(): v
+               for k, v in request_meta.items()
+               if k.startswith('HTTP_')}
     if 'CONTENT_TYPE' in request_meta:
         headers['Content-Type'] = request_meta['CONTENT_TYPE']
     if 'CONTENT_LENGTH' in request_meta:

--- a/mediator/tenants/views.py
+++ b/mediator/tenants/views.py
@@ -10,26 +10,22 @@ from django.views.decorators.csrf import csrf_exempt
 from tenants.models import Tenant, Upstream
 
 
-def join_url(*args):
+def slash_join(*args: str) -> str:
     """
-    Joins parts of a url.
+    Joins arguments with a single ``/``. Useful for concatenating
+    strings to form a URL.
 
-    >>> join_url('https://example.com/', '/foo')
+    >>> slash_join('https://example.com/', '/foo')
     'https://example.com/foo'
-    >>> join_url('https://example.com/', 'api/', '/path/to/some/resource/')
-    'https://example.com/api/path/to/some/resource/'
+    >>> slash_join('https://example.com', 'api/', '/resource-type/')
+    'https://example.com/api/resource-type/'
 
     """
-    parts = []
-    last_index = len(args) - 1
-    for i, arg in enumerate(args):
-        if i == 0:
-            parts.append(arg.rstrip('/'))
-        elif i == last_index:
-            parts.append(arg.lstrip('/'))
-        else:
-            parts.append(arg.strip('/'))
-    return '/'.join(parts)
+    if not args:
+        return ''
+    append_slash = args[-1].endswith('/')
+    joined = '/'.join([arg.strip('/') for arg in args])
+    return joined + '/' if append_slash else joined
 
 
 def get_http_headers(request_meta):
@@ -72,7 +68,7 @@ def get_body_as_string(requonse):
 
 
 def forward_request_upstream(request, upstream, path):
-    url = join_url(upstream.base_url, path)
+    url = slash_join(upstream.base_url, path)
     query_string = request.META['QUERY_STRING']
     body = get_body_as_string(request)
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django==2.2.18
-gunicorn==19.9.0
-Jinja2==2.11.3
--e git+https://github.com/de-laz/openhim-mediator-utils-py.git@7ad8dd4#egg=openhim-mediator-utils
-cryptography==3.3.2
-pytz==2018.9
-requests==2.21.0
+Django~=2.2
+gunicorn~=20.0
+Jinja2~=2.0
+-e git+https://github.com/de-laz/openhim-mediator-utils-py.git@de7069b#egg=openhim-mediator-utils
+cryptography~=3.0
+pytz==2021.1
+requests~=2.0


### PR DESCRIPTION
### Context

CommCare HQ can forward case data as FHIR resources to a remote FHIR API. A form that registers a patient and records a vaccination might be forwarded using the following workflow of consecutive API requests from CommCare:

1. Check the remote FHIR service for an existing, matching patient:

       GET https://fhir.example.com/r4/Patient/?name=Jane%20Doe

2. Register a new patient:

       POST https://fhir.example.com/r4/Patient/
       {
           "name": [{
               "text": "Jane Doe"
           }],
           "resourceType": "Patient"
       }

3. Create a new Immunization resource:

       POST https://fhir.example.com/r4/Immunization/
       {
           "vaccineCode": {
               "coding": [{
                   "system": "http://www.ama-assn.org/go/cpt",
                   "code": "91302",
                   "display": "AstraZeneca COVID-19 Vaccine"
               }],
               "text": "AstraZeneca COVID-19 Vaccine"
           },
           "occurrenceDateTime": "2021-04-28T16:51:00Z",
           "protocolApplied": {
               "doseNumberPositiveInt": 1,
               "seriesDosesPositiveInt": 2
           },
           "status": "completed",
           "patient": {
               "reference": "Patient/123"
           },
           "resourceType": "Immunization"
       }


Data forwarding in CommCare assumes that all API requests in a workflow are going to the same service.

But for one project, this is not the case.


### Summary

This pull request allows this OpenHIM mediator to be used for façading as a single API, and forwarding requests to upstream mediators, based on the URL and the HTTP method that the sender (e.g. CommCare HQ) is using.

For our purposes, this allows Request 1 to be redirected to an upstream mediator for a Customer Registry, Request 2 to be redirected to a different mediator for registering patients, and Request 3 to be redirected to an EMR. Responses will all appear as standard FHIR responses, and be returned to the sender as if they had come from a single service.

:blowfish: :fish: :tropical_fish: The first two commits are relevant. The rest update requirements, and refactor the views module a little.

### Motivation

We chose to use a mediator to do this, instead of building the functionality into CommCare, because
* the project already uses OpenHIM as an interoperability layer, so this mediator can just be added to an existing set of mediators
* this is relatively clean to implement in this mediator, and relatively clumsy to implement in CommCare
* this seems like an uncommon request. If we get more requests like this, it might be worthwhile incorporating this behavior into CommCare, but until then, YAGNI.

